### PR TITLE
Add endpoint GET /api/conferences/{id}/register

### DIFF
--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -27,6 +27,7 @@ Route::group(['prefix' => 'api/conferences', 'namespace' => 'Conference'], funct
         Route::post('register', 'RegistrationController@userRegistration');
         Route::post('register/{registryId}/approve', 'RegistrationController@approveRegistration');
         Route::get('register/{registryId}', 'RegistrationController@getRegistrationData');
+        Route::get('register', 'RegistrationController@outstandingRegistrationRequests');
 
         Route::group(['prefix' => 'residences'], function () {
             Route::get('', 'RoomSetupController@getResidenceList');


### PR DESCRIPTION
Allows retrieval of all registration requests, or subsets
based on approval status (with `?include=all|pending|approved`).